### PR TITLE
feat: 問い合わせフォームのサーバー側スパム対策

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 data/
 .env
 .env.*
+node_modules/
+.wrangler/
+.wrangler-dist/
+.clasp.json
+.dev.vars
+.dev.vars.*

--- a/contact-worker/apps-script/Code.gs
+++ b/contact-worker/apps-script/Code.gs
@@ -118,13 +118,23 @@ function doPost(event) {
     }
 
     try {
-      if (cache.get(cacheKey)) {
+      const fingerprint = payloadFingerprint_(payload, secret);
+      const cachedFingerprint = cache.get(cacheKey);
+      if (cachedFingerprint) {
+        if (!constantTimeHexEqual_(cachedFingerprint, fingerprint)) {
+          console.warn(JSON.stringify({
+            event: 'contact_receiver',
+            outcome: 'rejected',
+            reason: 'request_id_conflict',
+            requestId: requestId,
+          }));
+          return json_({ ok: false, code: 'request_id_conflict' });
+        }
         return json_({ ok: true, duplicate: true });
       }
 
       const sheet = getContactSheet_(properties);
       ensureHeaders_(sheet);
-      const fingerprint = payloadFingerprint_(payload, secret);
       const existingCell = findRequestRow_(sheet, requestId);
       if (existingCell) {
         const existingRowNumber = existingCell.getRow();
@@ -139,7 +149,7 @@ function doPost(event) {
           return json_({ ok: false, code: 'request_id_conflict' });
         }
         resumeDelivery_(properties, payload, sheet, existingRowNumber, deliveryState);
-        cache.put(cacheKey, 'accepted', 21600);
+        cache.put(cacheKey, fingerprint, 21600);
         console.log(JSON.stringify({
           event: 'contact_receiver',
           outcome: 'duplicate',
@@ -159,7 +169,7 @@ function doPost(event) {
         autoReplyEnabled ? '待機' : '停止',
         fingerprint,
       ]);
-      cache.put(cacheKey, 'accepted', 21600);
+      cache.put(cacheKey, fingerprint, 21600);
 
       console.log(JSON.stringify({
         event: 'contact_receiver',

--- a/contact-worker/apps-script/Code.gs
+++ b/contact-worker/apps-script/Code.gs
@@ -1,0 +1,417 @@
+const CONTACT_HEADERS = [
+  '受付日時',
+  '受付ID',
+  '企業名',
+  '部署・役職',
+  'お名前',
+  'メールアドレス',
+  '電話番号',
+  '住所',
+  'お問い合わせ内容',
+  '内部通知状態',
+  '自動返信状態',
+  '内容指紋',
+];
+
+/**
+ * One-time authorization helper for deployments created through clasp.
+ * Run this from the Apps Script editor as the deploying account. It requests
+ * the manifest scopes without reading or sending inquiry data.
+ */
+function authorizeContactReceiver() {
+  const effectiveUserAvailable = Boolean(Session.getEffectiveUser().getEmail());
+  const remainingDailyMailQuota = MailApp.getRemainingDailyQuota();
+  SpreadsheetApp.getActiveSpreadsheet();
+  return {
+    ok: effectiveUserAvailable,
+    remainingDailyMailQuota: remainingDailyMailQuota,
+  };
+}
+
+/**
+ * Initializes the production receiver after its notification recipients have
+ * been configured in Script Properties.
+ * This function is callable only through the MYSELF-scoped Execution API.
+ * The returned shared secret must be transferred directly to the Worker secret
+ * binding and must never be written to source control or logs.
+ */
+function configureContactReceiver(spreadsheetId, sheetName) {
+  const normalizedSpreadsheetId = String(spreadsheetId || '').trim();
+  const normalizedSheetName = String(sheetName || 'お問い合わせ').trim();
+  if (!/^[A-Za-z0-9_-]{20,}$/.test(normalizedSpreadsheetId)) {
+    throw new Error('invalid_spreadsheet_id');
+  }
+  if (!normalizedSheetName || normalizedSheetName.length > 100) {
+    throw new Error('invalid_sheet_name');
+  }
+
+  const properties = PropertiesService.getScriptProperties();
+  const recipients = splitEmailList_(properties.getProperty('CONTACT_NOTIFY_EMAILS'));
+  if (recipients.length === 0) {
+    throw new Error('notify_recipients_missing');
+  }
+  const sharedSecret = properties.getProperty('CONTACT_SHARED_SECRET') || [
+    Utilities.getUuid(),
+    Utilities.getUuid(),
+    Utilities.getUuid(),
+  ].join('').replace(/-/g, '');
+
+  properties.setProperties({
+    CONTACT_SHARED_SECRET: sharedSecret,
+    CONTACT_SPREADSHEET_ID: normalizedSpreadsheetId,
+    CONTACT_SHEET_NAME: normalizedSheetName,
+    CONTACT_NOTIFY_ENABLED: 'true',
+    CONTACT_AUTOREPLY_ENABLED: 'true',
+    CONTACT_FROM_NAME: 'アブロードアウトソーシング株式会社',
+  });
+
+  const sheet = getContactSheet_(properties);
+  ensureHeaders_(sheet);
+  return {
+    ok: true,
+    sharedSecret: sharedSecret,
+    notificationEnabled: true,
+    autoReplyEnabled: true,
+    notificationRecipientCount: recipients.length,
+  };
+}
+
+function getContactConfigurationStatus() {
+  const properties = PropertiesService.getScriptProperties();
+  const recipients = splitEmailList_(properties.getProperty('CONTACT_NOTIFY_EMAILS'));
+  const sheet = getContactSheet_(properties);
+  return {
+    ok: Boolean(properties.getProperty('CONTACT_SHARED_SECRET')),
+    spreadsheetAccessible: Boolean(sheet),
+    notificationEnabled: propertyIsTrue_(properties, 'CONTACT_NOTIFY_ENABLED'),
+    autoReplyEnabled: propertyIsTrue_(properties, 'CONTACT_AUTOREPLY_ENABLED'),
+    notificationRecipientCount: recipients.length,
+    remainingDailyMailQuota: MailApp.getRemainingDailyQuota(),
+  };
+}
+
+function doPost(event) {
+  const fallbackRequestId = Utilities.getUuid();
+  try {
+    const properties = PropertiesService.getScriptProperties();
+    const envelope = JSON.parse(event && event.postData ? event.postData.contents : '');
+    const secret = requireProperty_(properties, 'CONTACT_SHARED_SECRET');
+    if (!envelope || typeof envelope.payload !== 'string' || typeof envelope.signature !== 'string') {
+      return json_({ ok: false, code: 'invalid_envelope' });
+    }
+
+    const expectedSignature = hmacHex_(envelope.payload, secret);
+    if (!constantTimeHexEqual_(expectedSignature, envelope.signature)) {
+      console.warn(JSON.stringify({ event: 'contact_receiver', outcome: 'rejected', reason: 'invalid_signature' }));
+      return json_({ ok: false, code: 'invalid_signature' });
+    }
+
+    const payload = JSON.parse(envelope.payload);
+    validatePayload_(payload);
+    const requestId = payload.requestId || fallbackRequestId;
+    const cache = CacheService.getScriptCache();
+    const cacheKey = 'contact:' + requestId;
+
+    const lock = LockService.getScriptLock();
+    if (!lock.tryLock(5000)) {
+      return json_({ ok: false, code: 'receiver_busy' });
+    }
+
+    try {
+      if (cache.get(cacheKey)) {
+        return json_({ ok: true, duplicate: true });
+      }
+
+      const sheet = getContactSheet_(properties);
+      ensureHeaders_(sheet);
+      const fingerprint = payloadFingerprint_(payload, secret);
+      const existingCell = findRequestRow_(sheet, requestId);
+      if (existingCell) {
+        const existingRowNumber = existingCell.getRow();
+        const deliveryState = sheet.getRange(existingRowNumber, 10, 1, 3).getValues()[0];
+        if (!constantTimeHexEqual_(String(deliveryState[2] || ''), fingerprint)) {
+          console.warn(JSON.stringify({
+            event: 'contact_receiver',
+            outcome: 'rejected',
+            reason: 'request_id_conflict',
+            requestId: requestId,
+          }));
+          return json_({ ok: false, code: 'request_id_conflict' });
+        }
+        resumeDelivery_(properties, payload, sheet, existingRowNumber, deliveryState);
+        cache.put(cacheKey, 'accepted', 21600);
+        console.log(JSON.stringify({
+          event: 'contact_receiver',
+          outcome: 'duplicate',
+          requestId: requestId,
+        }));
+        return json_({ ok: true, duplicate: true });
+      }
+      const notifyEnabled = propertyIsTrue_(properties, 'CONTACT_NOTIFY_ENABLED')
+        && payload.controls.notificationEnabled === true;
+      const autoReplyEnabled = propertyIsTrue_(properties, 'CONTACT_AUTOREPLY_ENABLED')
+        && payload.controls.autoReplyEnabled === true;
+
+      sheet.appendRow(buildRow_(payload, notifyEnabled, autoReplyEnabled, fingerprint));
+      const rowNumber = sheet.getLastRow();
+      resumeDelivery_(properties, payload, sheet, rowNumber, [
+        notifyEnabled ? '待機' : '停止',
+        autoReplyEnabled ? '待機' : '停止',
+        fingerprint,
+      ]);
+      cache.put(cacheKey, 'accepted', 21600);
+
+      console.log(JSON.stringify({
+        event: 'contact_receiver',
+        outcome: 'accepted',
+        requestId: requestId,
+        notificationEnabled: notifyEnabled,
+        autoReplyEnabled: autoReplyEnabled,
+      }));
+      return json_({ ok: true });
+    } finally {
+      lock.releaseLock();
+    }
+  } catch (error) {
+    console.error(JSON.stringify({
+      event: 'contact_receiver',
+      outcome: 'error',
+      requestId: fallbackRequestId,
+      reason: safeErrorReason_(error),
+    }));
+    return json_({ ok: false, code: 'receiver_error' });
+  }
+}
+
+function validatePayload_(payload) {
+  if (!payload || payload.version !== 1 || !payload.fields || !payload.controls) {
+    throw new Error('invalid_payload');
+  }
+  if (!/^[0-9a-f-]{36}$/i.test(String(payload.requestId || ''))) {
+    throw new Error('invalid_request_id');
+  }
+
+  const fields = payload.fields;
+  const limits = {
+    enterprise: 120,
+    department: 120,
+    name: 80,
+    email: 254,
+    phone: 30,
+    address: 500,
+    inquiryDetails: 4000,
+  };
+  Object.keys(limits).forEach(function (field) {
+    if (typeof fields[field] !== 'string' || fields[field].length > limits[field]) {
+      throw new Error('invalid_field_' + field);
+    }
+  });
+  if (!fields.enterprise || !fields.name || !fields.email || !fields.phone || !fields.inquiryDetails) {
+    throw new Error('required_field_missing');
+  }
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(fields.email) || /[\r\n]/.test(fields.email)) {
+    throw new Error('invalid_email');
+  }
+}
+
+function getContactSheet_(properties) {
+  const spreadsheetId = requireProperty_(properties, 'CONTACT_SPREADSHEET_ID');
+  const sheetName = requireProperty_(properties, 'CONTACT_SHEET_NAME');
+  const spreadsheet = SpreadsheetApp.openById(spreadsheetId);
+  const sheet = spreadsheet.getSheetByName(sheetName);
+  if (!sheet) {
+    throw new Error('contact_sheet_not_found');
+  }
+  return sheet;
+}
+
+function ensureHeaders_(sheet) {
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow(CONTACT_HEADERS);
+  }
+}
+
+function findRequestRow_(sheet, requestId) {
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    return null;
+  }
+  return sheet
+    .getRange(2, 2, lastRow - 1, 1)
+    .createTextFinder(requestId)
+    .matchEntireCell(true)
+    .findNext();
+}
+
+function buildRow_(payload, notifyEnabled, autoReplyEnabled, fingerprint) {
+  const fields = payload.fields;
+  return [
+    new Date(payload.receivedAt),
+    escapeSheetValue_(payload.requestId),
+    escapeSheetValue_(fields.enterprise),
+    escapeSheetValue_(fields.department),
+    escapeSheetValue_(fields.name),
+    escapeSheetValue_(fields.email),
+    escapeSheetValue_(fields.phone),
+    escapeSheetValue_(fields.address),
+    escapeSheetValue_(fields.inquiryDetails),
+    notifyEnabled ? '待機' : '停止',
+    autoReplyEnabled ? '待機' : '停止',
+    fingerprint,
+  ];
+}
+
+function resumeDelivery_(properties, payload, sheet, rowNumber, deliveryState) {
+  if (deliveryState[0] === '待機') {
+    const notifyStillEnabled = propertyIsTrue_(properties, 'CONTACT_NOTIFY_ENABLED')
+      && payload.controls.notificationEnabled === true;
+    if (notifyStillEnabled) {
+      sendInternalNotification_(properties, payload, sheet, rowNumber);
+      sheet.getRange(rowNumber, 10).setValue('完了');
+    } else {
+      sheet.getRange(rowNumber, 10).setValue('停止');
+    }
+  }
+  if (deliveryState[1] === '待機') {
+    const autoReplyStillEnabled = propertyIsTrue_(properties, 'CONTACT_AUTOREPLY_ENABLED')
+      && payload.controls.autoReplyEnabled === true;
+    if (autoReplyStillEnabled) {
+      sendAutoReply_(properties, payload);
+      sheet.getRange(rowNumber, 11).setValue('完了');
+    } else {
+      sheet.getRange(rowNumber, 11).setValue('停止');
+    }
+  }
+}
+
+function payloadFingerprint_(payload, secret) {
+  return hmacHex_(JSON.stringify({
+    requestId: payload.requestId,
+    fields: payload.fields,
+  }), secret);
+}
+
+function sendInternalNotification_(properties, payload, sheet, rowNumber) {
+  const recipients = splitEmailList_(requireProperty_(properties, 'CONTACT_NOTIFY_EMAILS'));
+  if (recipients.length === 0) {
+    throw new Error('notify_recipients_missing');
+  }
+
+  const fields = payload.fields;
+  const rowUrl = sheet.getParent().getUrl() + '#gid=' + sheet.getSheetId() + '&range=A' + rowNumber;
+  const subject = '[問い合わせ] ' + safeSubjectPart_(fields.enterprise) + ' / ' + safeSubjectPart_(fields.name);
+  const body = [
+    'Webサイトから問い合わせを受け付けました。',
+    '',
+    '受付ID: ' + payload.requestId,
+    '企業名: ' + fields.enterprise,
+    '部署・役職: ' + fields.department,
+    'お名前: ' + fields.name,
+    'メールアドレス: ' + fields.email,
+    '電話番号: ' + fields.phone,
+    '住所: ' + fields.address,
+    '',
+    'お問い合わせ内容:',
+    fields.inquiryDetails,
+    '',
+    '回答行: ' + rowUrl,
+  ].join('\n');
+
+  MailApp.sendEmail({
+    to: recipients.join(','),
+    subject: subject,
+    body: body,
+    name: properties.getProperty('CONTACT_FROM_NAME') || 'Webサイト問い合わせ',
+  });
+}
+
+function sendAutoReply_(properties, payload) {
+  const fields = payload.fields;
+  const body = [
+    fields.name + ' 様',
+    '',
+    'お問い合わせを受け付けました。',
+    '内容を確認のうえ、担当者からご連絡いたします。',
+    '',
+    '受付ID: ' + payload.requestId,
+    '',
+    'このメールに心当たりがない場合は、返信せず削除してください。',
+  ].join('\n');
+
+  MailApp.sendEmail({
+    to: fields.email,
+    subject: 'お問い合わせを受け付けました',
+    body: body,
+    name: properties.getProperty('CONTACT_FROM_NAME') || 'アブロードアウトソーシング株式会社',
+  });
+}
+
+function escapeSheetValue_(value) {
+  const text = String(value == null ? '' : value);
+  return /^[=+\-@]/.test(text) ? "'" + text : text;
+}
+
+function safeSubjectPart_(value) {
+  return String(value || '').replace(/[\r\n]/g, ' ').slice(0, 80);
+}
+
+function splitEmailList_(value) {
+  return String(value || '')
+    .split(/[;,\n]/)
+    .map(function (item) { return item.trim(); })
+    .filter(function (item) { return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(item); });
+}
+
+function requireProperty_(properties, name) {
+  const value = properties.getProperty(name);
+  if (!value) {
+    throw new Error(name.toLowerCase() + '_missing');
+  }
+  return value;
+}
+
+function propertyIsTrue_(properties, name) {
+  return properties.getProperty(name) === 'true';
+}
+
+function hmacHex_(value, secret) {
+  return Utilities.computeHmacSha256Signature(value, secret)
+    .map(function (byte) {
+      const normalized = byte < 0 ? byte + 256 : byte;
+      return normalized.toString(16).padStart(2, '0');
+    })
+    .join('');
+}
+
+function constantTimeHexEqual_(left, right) {
+  if (typeof left !== 'string' || typeof right !== 'string' || left.length !== right.length) {
+    return false;
+  }
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+function safeErrorReason_(error) {
+  const allowed = [
+    'invalid_payload',
+    'invalid_request_id',
+    'required_field_missing',
+    'invalid_email',
+    'contact_sheet_not_found',
+    'notify_recipients_missing',
+  ];
+  const message = error && error.message ? error.message : 'unknown_error';
+  if (allowed.indexOf(message) >= 0 || /_missing$/.test(message) || /^invalid_field_/.test(message)) {
+    return message;
+  }
+  return 'unexpected_error';
+}
+
+function json_(body) {
+  return ContentService
+    .createTextOutput(JSON.stringify(body))
+    .setMimeType(ContentService.MimeType.JSON);
+}

--- a/contact-worker/apps-script/README.md
+++ b/contact-worker/apps-script/README.md
@@ -1,0 +1,34 @@
+# Apps Script問い合わせ受信処理
+
+Cloudflare WorkerがTurnstile・入力検証・レート制限を通過した問い合わせだけを、HMAC署名付きでこのWebアプリへ送ります。WebアプリURLと共有鍵は公開HTMLへ置きません。
+
+## Script Properties
+
+初回デプロイ前に、新しい台帳を既存の問い合わせ運用グループへ共有し、各担当者が開けることを確認します。通知先はソースや実行引数ではなく、Apps ScriptのScript Propertiesでその運用グループに設定します。実アドレスはこのREADME、GitHub、ログへ残しません。
+
+`CONTACT_NOTIFY_EMAILS`を設定した後、本人限定のExecution APIから次を1回実行すると、保存先・メール有効化設定と共有鍵を安全に初期化できます。
+
+```text
+configureContactReceiver(<spreadsheet id>, "お問い合わせ")
+```
+
+この初期化は`CONTACT_NOTIFY_EMAILS`を変更しません。内部通知・自動返信はいずれも`true`になります。戻り値の`sharedSecret`だけをWorkerの`UPSTREAM_SHARED_SECRET`へ直接移し、端末出力、Issue、ソースへ残さないでください。設定後は`getContactConfigurationStatus()`を実行し、シート到達性、通知先件数、両メール経路の有効状態、残りメール枠を確認します。
+
+必須:
+
+- `CONTACT_SHARED_SECRET`: Workerの`UPSTREAM_SHARED_SECRET`と同じ十分に長いランダム値
+- `CONTACT_SPREADSHEET_ID`: 回答保存先スプレッドシートID
+- `CONTACT_SHEET_NAME`: 回答保存先シート名
+- `CONTACT_NOTIFY_ENABLED`: 内部通知を有効にする場合だけ`true`
+- `CONTACT_AUTOREPLY_ENABLED`: 通常運用では`true`。インシデント対応やメール経路障害時だけ`false`
+
+内部通知を有効にする場合:
+
+- `CONTACT_NOTIFY_EMAILS`: カンマ、セミコロン、改行区切りの通知先
+- `CONTACT_FROM_NAME`: 任意の差出人表示名
+
+## 公開条件
+
+Webアプリは「自分として実行」「全員（匿名ユーザーを含む）がアクセス可能」でデプロイします。Execution APIは本人限定です。匿名アクセスを許可しても、正しいHMAC署名がない本文は保存・通知・自動返信されません。
+
+実データで試す前に、テスト用スプレッドシート・通知先で動作確認してください。実際のメールアドレスや共有鍵をGitHub Issue、ソース、ログへ貼り付けないでください。

--- a/contact-worker/apps-script/appsscript.json
+++ b/contact-worker/apps-script/appsscript.json
@@ -1,0 +1,18 @@
+{
+  "timeZone": "Asia/Tokyo",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.send_mail",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ],
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  },
+  "executionApi": {
+    "access": "MYSELF"
+  }
+}

--- a/contact-worker/package-lock.json
+++ b/contact-worker/package-lock.json
@@ -1,0 +1,1540 @@
+{
+  "name": "abroad-o-contact-worker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "abroad-o-contact-worker",
+      "version": "1.0.0",
+      "devDependencies": {
+        "wrangler": "4.118.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.23.tgz",
+      "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260730.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260730.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260730.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260730.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/contact-worker/package.json
+++ b/contact-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "abroad-o-contact-worker",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/*.test.js",
+    "check": "node --check src/index.js && wrangler deploy --dry-run --outdir .wrangler-dist"
+  },
+  "devDependencies": {
+    "wrangler": "4.118.0"
+  }
+}

--- a/contact-worker/src/index.js
+++ b/contact-worker/src/index.js
@@ -1,0 +1,495 @@
+const MAX_REQUEST_BYTES = 32 * 1024;
+const MAX_UPSTREAM_RESPONSE_BYTES = 4 * 1024;
+const MIN_SUBMISSION_TIME_MS = 3_000;
+const MAX_SUBMISSION_TIME_MS = 2 * 60 * 60 * 1_000;
+const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+const FIELD_RULES = {
+  enterprise: { required: true, max: 120 },
+  department: { required: false, max: 120 },
+  name: { required: true, max: 80 },
+  email: { required: true, max: 254 },
+  phone: { required: true, max: 30 },
+  address: { required: false, max: 500 },
+  inquiryDetails: { required: true, max: 4000 },
+};
+
+export default {
+  async fetch(request, env) {
+    return handleRequest(request, env);
+  },
+};
+
+export async function handleRequest(request, env) {
+  const requestId = crypto.randomUUID();
+  const url = new URL(request.url);
+  const origin = request.headers.get('Origin');
+  const allowedOrigin = getAllowedOrigin(origin, env.ALLOWED_ORIGINS);
+
+  if (request.method === 'OPTIONS') {
+    if (!allowedOrigin) {
+      return jsonResponse({ ok: false, code: 'origin_not_allowed' }, 403, null);
+    }
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(allowedOrigin),
+    });
+  }
+
+  if (request.method === 'GET' && url.pathname === '/health') {
+    return jsonResponse({ ok: true, service: 'contact-form' }, 200, allowedOrigin);
+  }
+
+  if (request.method === 'GET' && url.pathname === '/config') {
+    if (!allowedOrigin) {
+      return jsonResponse({ ok: false, code: 'origin_not_allowed' }, 403, null);
+    }
+    if (!env.TURNSTILE_SITE_KEY) {
+      audit('config_error', requestId, 'turnstile_site_key_missing');
+      return jsonResponse({ ok: false, code: 'service_unavailable' }, 503, allowedOrigin);
+    }
+    return jsonResponse({
+      ok: true,
+      turnstileSiteKey: env.TURNSTILE_SITE_KEY,
+      turnstileAction: env.TURNSTILE_ACTION || 'contact-submit',
+    }, 200, allowedOrigin);
+  }
+
+  if (request.method !== 'POST' || url.pathname !== '/submit') {
+    return jsonResponse({ ok: false, code: 'not_found' }, 404, allowedOrigin);
+  }
+
+  if (!allowedOrigin) {
+    audit('rejected', requestId, 'origin_not_allowed');
+    return jsonResponse({ ok: false, code: 'request_rejected' }, 403, null);
+  }
+
+  const missingConfig = requiredConfiguration(env);
+  if (missingConfig) {
+    audit('config_error', requestId, missingConfig);
+    return jsonResponse({ ok: false, code: 'service_unavailable' }, 503, allowedOrigin);
+  }
+
+  try {
+    const contentType = request.headers.get('Content-Type') || '';
+    if (!contentType.toLowerCase().startsWith('application/json')) {
+      return reject(requestId, 'unsupported_content_type', 415, allowedOrigin);
+    }
+
+    const declaredLength = Number(request.headers.get('Content-Length') || 0);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_REQUEST_BYTES) {
+      return reject(requestId, 'request_too_large', 413, allowedOrigin);
+    }
+
+    const requestText = await request.text();
+    if (new TextEncoder().encode(requestText).byteLength > MAX_REQUEST_BYTES) {
+      return reject(requestId, 'request_too_large', 413, allowedOrigin);
+    }
+
+    let input;
+    try {
+      input = JSON.parse(requestText);
+    } catch {
+      return reject(requestId, 'invalid_json', 400, allowedOrigin);
+    }
+
+    const validation = validateSubmission(input);
+    if (!validation.ok) {
+      return reject(requestId, validation.reason, 400, allowedOrigin, validation.fields);
+    }
+
+    const submission = validation.value;
+    const clientIp = request.headers.get('CF-Connecting-IP');
+    if (!clientIp) {
+      return reject(requestId, 'client_identity_missing', 503, allowedOrigin);
+    }
+
+    const [ipKey, emailKey] = await Promise.all([
+      keyedHash(env.RATE_LIMIT_HASH_KEY, `ip:${clientIp}`),
+      keyedHash(env.RATE_LIMIT_HASH_KEY, `email:${submission.email.toLowerCase()}`),
+    ]);
+
+    const ipLimit = await env.IP_RATE_LIMITER.limit({ key: ipKey });
+    if (!ipLimit.success) {
+      audit('rejected', requestId, 'rate_limited', ipKey);
+      return jsonResponse({ ok: false, code: 'rate_limited' }, 429, allowedOrigin, {
+        'Retry-After': '60',
+      });
+    }
+
+    const turnstile = await verifyTurnstile({
+      token: submission.turnstileToken,
+      clientIp,
+      secret: env.TURNSTILE_SECRET_KEY,
+      expectedAction: env.TURNSTILE_ACTION || 'contact-submit',
+      allowedHostnames: csv(env.ALLOWED_HOSTNAMES),
+    });
+    if (!turnstile.ok) {
+      audit('rejected', requestId, turnstile.reason, ipKey);
+      return jsonResponse({ ok: false, code: 'verification_failed' }, 400, allowedOrigin);
+    }
+
+    // Only a successfully verified visitor may consume the target-address quota.
+    // This prevents invalid-token traffic from blocking a legitimate sender who
+    // happens to use the same reply address.
+    const emailLimit = await env.EMAIL_RATE_LIMITER.limit({ key: emailKey });
+    if (!emailLimit.success) {
+      audit('rejected', requestId, 'rate_limited', ipKey);
+      return jsonResponse({ ok: false, code: 'rate_limited' }, 429, allowedOrigin, {
+        'Retry-After': '60',
+      });
+    }
+
+    const upstreamPayload = {
+      version: 1,
+      requestId: submission.submissionId,
+      receivedAt: new Date().toISOString(),
+      fields: {
+        enterprise: submission.enterprise,
+        department: submission.department,
+        name: submission.name,
+        email: submission.email,
+        phone: submission.phone,
+        address: submission.address,
+        inquiryDetails: submission.inquiryDetails,
+      },
+      controls: {
+        notificationEnabled: env.NOTIFY_ENABLED === 'true',
+        autoReplyEnabled: env.AUTOREPLY_ENABLED === 'true',
+      },
+    };
+
+    const upstreamResult = await sendToUpstream(upstreamPayload, env);
+    if (!upstreamResult.ok) {
+      audit('upstream_error', requestId, upstreamResult.reason, ipKey);
+      return jsonResponse({ ok: false, code: 'service_unavailable' }, 503, allowedOrigin);
+    }
+
+    audit('accepted', requestId, 'verified_and_forwarded', ipKey);
+    return jsonResponse({ ok: true, requestId: submission.submissionId }, 200, allowedOrigin);
+  } catch (error) {
+    audit('internal_error', requestId, safeErrorReason(error));
+    return jsonResponse({ ok: false, code: 'service_unavailable' }, 503, allowedOrigin);
+  }
+}
+
+export function validateSubmission(input, now = Date.now()) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { ok: false, reason: 'invalid_payload' };
+  }
+  if (typeof input.website !== 'string' || input.website !== '') {
+    return { ok: false, reason: 'honeypot_filled' };
+  }
+  if (input.consent !== true) {
+    return { ok: false, reason: 'consent_missing', fields: ['consent'] };
+  }
+  if (!isUuid(input.submissionId)) {
+    return { ok: false, reason: 'invalid_submission_id' };
+  }
+  if (!Number.isFinite(input.formStartedAt)) {
+    return { ok: false, reason: 'invalid_form_time' };
+  }
+
+  const elapsed = now - input.formStartedAt;
+  if (elapsed < MIN_SUBMISSION_TIME_MS) {
+    return { ok: false, reason: 'submission_too_fast' };
+  }
+  if (elapsed > MAX_SUBMISSION_TIME_MS) {
+    return { ok: false, reason: 'form_expired' };
+  }
+
+  const normalized = {};
+  const invalidFields = [];
+  for (const [field, rule] of Object.entries(FIELD_RULES)) {
+    if (typeof input[field] !== 'string') {
+      invalidFields.push(field);
+      continue;
+    }
+    const value = input[field].normalize('NFC').trim();
+    if ((rule.required && value.length === 0) || value.length > rule.max) {
+      invalidFields.push(field);
+      continue;
+    }
+    normalized[field] = value;
+  }
+
+  if (normalized.email && !isValidEmail(normalized.email)) {
+    invalidFields.push('email');
+  }
+  if (normalized.phone && !/^[0-9+() -]{7,30}$/.test(normalized.phone)) {
+    invalidFields.push('phone');
+  }
+  if (normalized.inquiryDetails && countUrls(normalized.inquiryDetails) > 5) {
+    invalidFields.push('inquiryDetails');
+  }
+  if (invalidFields.length > 0) {
+    return {
+      ok: false,
+      reason: 'field_validation_failed',
+      fields: [...new Set(invalidFields)],
+    };
+  }
+  if (typeof input.turnstileToken !== 'string'
+    || input.turnstileToken.length === 0
+    || input.turnstileToken.length > 2048) {
+    return { ok: false, reason: 'turnstile_token_invalid' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...normalized,
+      submissionId: input.submissionId.toLowerCase(),
+      turnstileToken: input.turnstileToken,
+    },
+  };
+}
+
+export async function verifyTurnstile({
+  token,
+  clientIp,
+  secret,
+  expectedAction,
+  allowedHostnames,
+}) {
+  const formData = new FormData();
+  formData.append('secret', secret);
+  formData.append('response', token);
+  formData.append('remoteip', clientIp);
+  formData.append('idempotency_key', crypto.randomUUID());
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 8_000);
+  try {
+    const response = await fetch(TURNSTILE_VERIFY_URL, {
+      method: 'POST',
+      body: formData,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return { ok: false, reason: 'turnstile_service_error' };
+    }
+    const result = await readLimitedJson(response, MAX_UPSTREAM_RESPONSE_BYTES);
+    if (result.success !== true) {
+      return { ok: false, reason: 'turnstile_rejected' };
+    }
+    if (result.action !== expectedAction) {
+      return { ok: false, reason: 'turnstile_action_mismatch' };
+    }
+    if (!allowedHostnames.includes(result.hostname)) {
+      return { ok: false, reason: 'turnstile_hostname_mismatch' };
+    }
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error && error.name === 'AbortError'
+        ? 'turnstile_timeout'
+        : 'turnstile_service_error',
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function sendToUpstream(payload, env) {
+  const upstreamUrl = new URL(env.UPSTREAM_URL);
+  if (upstreamUrl.protocol !== 'https:'
+    || !csv(env.UPSTREAM_ALLOWED_HOSTS).includes(upstreamUrl.hostname)) {
+    return { ok: false, reason: 'upstream_url_not_allowed' };
+  }
+
+  const payloadText = JSON.stringify(payload);
+  const signature = await keyedHash(env.UPSTREAM_SHARED_SECRET, payloadText);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const response = await fetch(upstreamUrl, {
+      method: 'POST',
+      redirect: 'follow',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Contact-Version': '1',
+      },
+      body: JSON.stringify({ payload: payloadText, signature }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return { ok: false, reason: 'upstream_http_error' };
+    }
+    const result = await readLimitedJson(response, MAX_UPSTREAM_RESPONSE_BYTES);
+    return result && result.ok === true
+      ? { ok: true }
+      : { ok: false, reason: 'upstream_rejected' };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error && error.name === 'AbortError'
+        ? 'upstream_timeout'
+        : 'upstream_request_failed',
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function keyedHash(secret, value) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(value));
+  return [...new Uint8Array(signature)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function readLimitedJson(response, limit) {
+  if (!response.body) {
+    throw new Error('empty_response');
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let text = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      throw new Error('response_too_large');
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return JSON.parse(text);
+}
+
+function requiredConfiguration(env) {
+  const required = [
+    'TURNSTILE_SECRET_KEY',
+    'RATE_LIMIT_HASH_KEY',
+    'UPSTREAM_URL',
+    'UPSTREAM_SHARED_SECRET',
+    'ALLOWED_HOSTNAMES',
+    'UPSTREAM_ALLOWED_HOSTS',
+  ];
+  for (const key of required) {
+    if (!env[key]) {
+      return `${key.toLowerCase()}_missing`;
+    }
+  }
+  if (!env.IP_RATE_LIMITER || !env.EMAIL_RATE_LIMITER) {
+    return 'rate_limiter_binding_missing';
+  }
+  return null;
+}
+
+function getAllowedOrigin(origin, configuredOrigins) {
+  if (!origin) {
+    return null;
+  }
+  return csv(configuredOrigins).includes(origin) ? origin : null;
+}
+
+function corsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '600',
+    'Vary': 'Origin',
+  };
+}
+
+function jsonResponse(body, status, origin, extraHeaders = {}) {
+  const headers = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+    ...extraHeaders,
+  };
+  if (origin) {
+    Object.assign(headers, corsHeaders(origin));
+  }
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+function reject(requestId, reason, status, origin, fields) {
+  audit('rejected', requestId, reason);
+  const body = { ok: false, code: 'request_rejected' };
+  if (fields) {
+    body.fields = fields;
+  }
+  return jsonResponse(body, status, origin);
+}
+
+function audit(outcome, requestId, reason, actorKey = '') {
+  const entry = {
+    event: 'contact_submission',
+    outcome,
+    requestId,
+    reason,
+  };
+  if (actorKey) {
+    entry.actorHash = actorKey.slice(0, 16);
+  }
+  const serialized = JSON.stringify(entry);
+  if (outcome === 'accepted') {
+    console.log(serialized);
+  } else if (outcome === 'rejected') {
+    console.warn(serialized);
+  } else {
+    console.error(serialized);
+  }
+}
+
+function csv(value) {
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function isUuid(value) {
+  return typeof value === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function isValidEmail(value) {
+  if (value.length > 254 || /[\r\n]/.test(value)) {
+    return false;
+  }
+  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value);
+}
+
+function countUrls(value) {
+  return (value.match(/https?:\/\/|www\./gi) || []).length;
+}
+
+function safeErrorReason(error) {
+  if (!error || typeof error !== 'object') {
+    return 'unknown_error';
+  }
+  const allowed = new Set([
+    'empty_response',
+    'response_too_large',
+    'SyntaxError',
+    'TypeError',
+  ]);
+  if (allowed.has(error.message)) {
+    return error.message;
+  }
+  if (allowed.has(error.name)) {
+    return error.name;
+  }
+  return 'unexpected_error';
+}

--- a/contact-worker/test/apps-script.test.js
+++ b/contact-worker/test/apps-script.test.js
@@ -250,6 +250,20 @@ test('Apps Script receiver stores once, escapes formulas and keeps auto-reply di
   assert.equal(logText.includes('サービスについて相談'), false);
 });
 
+test('Apps Script receiver rejects changed content when the duplicate cache is populated', () => {
+  const harness = createHarness();
+  const first = harness.context.doPost(signedEvent());
+  assert.deepEqual(JSON.parse(first.text), { ok: true });
+  assert.equal(harness.cache.size, 1);
+
+  const conflict = harness.context.doPost(signedEvent({
+    inquiryDetails: '内容を変更した再送です。',
+  }));
+  assert.deepEqual(JSON.parse(conflict.text), { ok: false, code: 'request_id_conflict' });
+  assert.equal(harness.rows.length, 2);
+  assert.equal(harness.sentEmails.length, 1);
+});
+
 test('Apps Script receiver requires both signed controls and Script Properties for mail', () => {
   const harness = createHarness({
     CONTACT_NOTIFY_ENABLED: 'false',

--- a/contact-worker/test/apps-script.test.js
+++ b/contact-worker/test/apps-script.test.js
@@ -1,0 +1,323 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(here, '..', 'apps-script', 'Code.gs'), 'utf8');
+
+function createHarness(propertyOverrides = {}, options = {}) {
+  const properties = {
+    CONTACT_SHARED_SECRET: 'shared-secret-for-tests',
+    CONTACT_SPREADSHEET_ID: 'spreadsheet-id',
+    CONTACT_SHEET_NAME: 'お問い合わせ',
+    CONTACT_NOTIFY_ENABLED: 'true',
+    CONTACT_AUTOREPLY_ENABLED: 'false',
+    CONTACT_NOTIFY_EMAILS: 'operations@example.invalid',
+    ...propertyOverrides,
+  };
+  const rows = [];
+  const sentEmails = [];
+  const cache = new Map();
+  const logs = [];
+  let remainingMailFailures = options.mailFailures || 0;
+
+  const sheet = {
+    appendRow(row) {
+      rows.push(row);
+    },
+    getLastRow() {
+      return rows.length;
+    },
+    getParent() {
+      return { getUrl: () => 'https://docs.google.com/spreadsheets/d/test' };
+    },
+    getSheetId() {
+      return 123;
+    },
+    getRange(startRow, startColumn, rowCount = 1, columnCount = 1) {
+      return {
+        createTextFinder(searchValue) {
+          let exact = false;
+          return {
+            matchEntireCell(value) {
+              exact = value;
+              return this;
+            },
+            findNext() {
+              const values = rows.slice(startRow - 1, startRow - 1 + rowCount);
+              const offset = values.findIndex((row) => {
+                const cell = String(row[startColumn - 1] || '');
+                return exact ? cell === searchValue : cell.includes(searchValue);
+              });
+              return offset >= 0 ? { getRow: () => startRow + offset } : null;
+            },
+          };
+        },
+        getValues() {
+          return rows
+            .slice(startRow - 1, startRow - 1 + rowCount)
+            .map((row) => row.slice(startColumn - 1, startColumn - 1 + columnCount));
+        },
+        setValue(value) {
+          rows[startRow - 1][startColumn - 1] = value;
+          return this;
+        },
+      };
+    },
+  };
+
+  const context = vm.createContext({
+    console: {
+      log: (value) => logs.push(String(value)),
+      warn: (value) => logs.push(String(value)),
+      error: (value) => logs.push(String(value)),
+    },
+    Utilities: {
+      getUuid: () => 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+      computeHmacSha256Signature(value, secret) {
+        return [...crypto.createHmac('sha256', secret).update(value).digest()]
+          .map((byte) => (byte > 127 ? byte - 256 : byte));
+      },
+    },
+    PropertiesService: {
+      getScriptProperties() {
+        return {
+          getProperty: (name) => properties[name] || null,
+          setProperties(values) {
+            Object.assign(properties, values);
+            return this;
+          },
+        };
+      },
+    },
+    Session: {
+      getEffectiveUser() {
+        return { getEmail: () => 'owner@example.invalid' };
+      },
+    },
+    CacheService: {
+      getScriptCache() {
+        return {
+          get: (key) => cache.get(key) || null,
+          put: (key, value) => cache.set(key, value),
+        };
+      },
+    },
+    LockService: {
+      getScriptLock() {
+        return { tryLock: () => true, releaseLock: () => {} };
+      },
+    },
+    SpreadsheetApp: {
+      openById() {
+        return { getSheetByName: () => sheet };
+      },
+    },
+    MailApp: {
+      getRemainingDailyQuota() {
+        return 1499;
+      },
+      sendEmail(message) {
+        if (remainingMailFailures > 0) {
+          remainingMailFailures -= 1;
+          throw new Error('mail_send_failed');
+        }
+        sentEmails.push(message);
+      },
+    },
+    ContentService: {
+      MimeType: { JSON: 'application/json' },
+      createTextOutput(text) {
+        return {
+          text,
+          setMimeType() {
+            return this;
+          },
+        };
+      },
+    },
+    Date,
+    JSON,
+    String,
+    RegExp,
+    Object,
+    Array,
+    Error,
+  });
+  vm.runInContext(source, context, { filename: 'Code.gs' });
+  return { context, rows, sentEmails, cache, logs, properties };
+}
+
+test('Apps Script production setup preserves Script Properties recipients and enables both mail paths', () => {
+  const harness = createHarness({ CONTACT_SHARED_SECRET: '' });
+  const result = harness.context.configureContactReceiver(
+    'spreadsheet-id-abcdefghijklmnop',
+    'お問い合わせ',
+  );
+
+  assert.equal(result.ok, true);
+  assert.match(result.sharedSecret, /^[0-9a-f]{96}$/);
+  assert.equal(result.notificationEnabled, true);
+  assert.equal(result.autoReplyEnabled, true);
+  assert.equal(result.notificationRecipientCount, 1);
+  assert.equal(harness.properties.CONTACT_NOTIFY_ENABLED, 'true');
+  assert.equal(harness.properties.CONTACT_AUTOREPLY_ENABLED, 'true');
+  assert.equal(harness.properties.CONTACT_NOTIFY_EMAILS, 'operations@example.invalid');
+
+  const status = harness.context.getContactConfigurationStatus();
+  assert.equal(status.ok, true);
+  assert.equal(status.spreadsheetAccessible, true);
+  assert.equal(status.remainingDailyMailQuota, 1499);
+});
+
+test('Apps Script production setup requires notification recipients in Script Properties', () => {
+  const harness = createHarness({ CONTACT_NOTIFY_EMAILS: '' });
+  assert.throws(
+    () => harness.context.configureContactReceiver('spreadsheet-id-abcdefghijklmnop', 'お問い合わせ'),
+    /notify_recipients_missing/,
+  );
+});
+
+function signedEvent(fields = {}, controls = {}) {
+  const payload = JSON.stringify({
+    version: 1,
+    requestId: '9f2208d4-6f4d-4d5a-86cc-572c690f4e25',
+    receivedAt: '2026-08-03T00:00:00.000Z',
+    fields: {
+      enterprise: 'テスト株式会社',
+      department: '営業部',
+      name: 'テスト担当',
+      email: 'visitor@example.net',
+      phone: '03-1234-5678',
+      address: '東京都',
+      inquiryDetails: 'サービスについて相談したいです。',
+      ...fields,
+    },
+    controls: {
+      notificationEnabled: true,
+      autoReplyEnabled: false,
+      ...controls,
+    },
+  });
+  const signature = crypto
+    .createHmac('sha256', 'shared-secret-for-tests')
+    .update(payload)
+    .digest('hex');
+  return { postData: { contents: JSON.stringify({ payload, signature }) } };
+}
+
+test('Apps Script receiver rejects an invalid signature before storage or mail', () => {
+  const harness = createHarness();
+  const event = signedEvent();
+  const envelope = JSON.parse(event.postData.contents);
+  envelope.signature = '0'.repeat(64);
+  event.postData.contents = JSON.stringify(envelope);
+
+  const result = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(result.text), { ok: false, code: 'invalid_signature' });
+  assert.equal(harness.rows.length, 0);
+  assert.equal(harness.sentEmails.length, 0);
+});
+
+test('Apps Script receiver stores once, escapes formulas and keeps auto-reply disabled', () => {
+  const harness = createHarness();
+  const event = signedEvent({ enterprise: '=IMPORTDATA("https://example.test")' });
+
+  const first = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(first.text), { ok: true });
+  assert.equal(harness.rows.length, 2);
+  assert.equal(harness.rows[1][2].startsWith("'="), true);
+  assert.equal(harness.rows[1][9], '完了');
+  assert.equal(harness.rows[1][10], '停止');
+  assert.match(harness.rows[1][11], /^[0-9a-f]{64}$/);
+  assert.equal(harness.sentEmails.length, 1);
+  assert.equal(harness.sentEmails[0].to, 'operations@example.invalid');
+
+  // CacheService is only an optimization. Clearing it proves that the
+  // Spreadsheet request-id index remains the durable idempotency boundary.
+  harness.cache.clear();
+  const second = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(second.text), { ok: true, duplicate: true });
+  assert.equal(harness.rows.length, 2);
+  assert.equal(harness.sentEmails.length, 1);
+
+  const logText = harness.logs.join('\n');
+  assert.equal(logText.includes('visitor@example.net'), false);
+  assert.equal(logText.includes('サービスについて相談'), false);
+});
+
+test('Apps Script receiver requires both signed controls and Script Properties for mail', () => {
+  const harness = createHarness({
+    CONTACT_NOTIFY_ENABLED: 'false',
+    CONTACT_AUTOREPLY_ENABLED: 'false',
+  });
+  const result = harness.context.doPost(signedEvent({}, {
+    notificationEnabled: true,
+    autoReplyEnabled: true,
+  }));
+
+  assert.deepEqual(JSON.parse(result.text), { ok: true });
+  assert.equal(harness.sentEmails.length, 0);
+  assert.equal(harness.rows[1][9], '停止');
+  assert.equal(harness.rows[1][10], '停止');
+});
+
+test('Apps Script receiver sends notification and auto-reply when both production gates are enabled', () => {
+  const harness = createHarness({
+    CONTACT_NOTIFY_ENABLED: 'true',
+    CONTACT_AUTOREPLY_ENABLED: 'true',
+  });
+  const result = harness.context.doPost(signedEvent({}, {
+    notificationEnabled: true,
+    autoReplyEnabled: true,
+  }));
+
+  assert.deepEqual(JSON.parse(result.text), { ok: true });
+  assert.equal(harness.sentEmails.length, 2);
+  assert.equal(harness.sentEmails[0].to, 'operations@example.invalid');
+  assert.equal(harness.sentEmails[1].to, 'visitor@example.net');
+  assert.equal(harness.rows[1][9], '完了');
+  assert.equal(harness.rows[1][10], '完了');
+});
+
+test('Apps Script receiver resumes a pending notification after a mail failure', () => {
+  const harness = createHarness({}, { mailFailures: 1 });
+  const event = signedEvent();
+
+  const failed = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(failed.text), { ok: false, code: 'receiver_error' });
+  assert.equal(harness.rows.length, 2);
+  assert.equal(harness.rows[1][9], '待機');
+  assert.equal(harness.cache.size, 0);
+
+  const retried = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(retried.text), { ok: true, duplicate: true });
+  assert.equal(harness.rows.length, 2);
+  assert.equal(harness.rows[1][9], '完了');
+  assert.equal(harness.sentEmails.length, 1);
+});
+
+test('Apps Script receiver honors an emergency mail stop before resuming pending work', () => {
+  const harness = createHarness({
+    CONTACT_NOTIFY_ENABLED: 'false',
+    CONTACT_AUTOREPLY_ENABLED: 'true',
+  }, { mailFailures: 1 });
+  const event = signedEvent({}, {
+    notificationEnabled: false,
+    autoReplyEnabled: true,
+  });
+
+  const failed = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(failed.text), { ok: false, code: 'receiver_error' });
+  assert.equal(harness.rows[1][10], '待機');
+
+  harness.properties.CONTACT_AUTOREPLY_ENABLED = 'false';
+  const retried = harness.context.doPost(event);
+  assert.deepEqual(JSON.parse(retried.text), { ok: true, duplicate: true });
+  assert.equal(harness.rows[1][10], '停止');
+  assert.equal(harness.sentEmails.length, 0);
+});

--- a/contact-worker/test/index.test.js
+++ b/contact-worker/test/index.test.js
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  handleRequest,
+  keyedHash,
+  validateSubmission,
+} from '../src/index.js';
+
+const ORIGIN = 'https://www.abroad-o.com';
+const SUBMISSION_ID = '9f2208d4-6f4d-4d5a-86cc-572c690f4e25';
+
+function validPayload(overrides = {}) {
+  return {
+    submissionId: SUBMISSION_ID,
+    enterprise: 'テスト株式会社',
+    department: '営業部',
+    name: 'テスト担当',
+    email: 'visitor@example.net',
+    phone: '+81 3 1234 5678',
+    address: '東京都',
+    inquiryDetails: 'サービスについて相談したいです。',
+    consent: true,
+    website: '',
+    formStartedAt: Date.now() - 5000,
+    turnstileToken: 'valid-turnstile-token',
+    ...overrides,
+  };
+}
+
+function fakeLimiter(success = true) {
+  return {
+    calls: [],
+    async limit(options) {
+      this.calls.push(options);
+      return { success };
+    },
+  };
+}
+
+function validEnv(overrides = {}) {
+  return {
+    ALLOWED_ORIGINS: `${ORIGIN},https://abroad-o.com`,
+    ALLOWED_HOSTNAMES: 'www.abroad-o.com,abroad-o.com',
+    UPSTREAM_ALLOWED_HOSTS: 'script.google.com',
+    TURNSTILE_ACTION: 'contact-submit',
+    TURNSTILE_SITE_KEY: 'public-site-key',
+    TURNSTILE_SECRET_KEY: 'turnstile-secret-for-tests',
+    RATE_LIMIT_HASH_KEY: 'rate-limit-secret-for-tests',
+    UPSTREAM_URL: 'https://script.google.com/macros/s/test/exec',
+    UPSTREAM_SHARED_SECRET: 'upstream-secret-for-tests',
+    NOTIFY_ENABLED: 'true',
+    AUTOREPLY_ENABLED: 'true',
+    IP_RATE_LIMITER: fakeLimiter(),
+    EMAIL_RATE_LIMITER: fakeLimiter(),
+    ...overrides,
+  };
+}
+
+function submitRequest(payload, headers = {}) {
+  return new Request('https://contact.example/submit', {
+    method: 'POST',
+    headers: {
+      Origin: ORIGIN,
+      'Content-Type': 'application/json',
+      'CF-Connecting-IP': '203.0.113.42',
+      ...headers,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+function silenceAudit() {
+  const original = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  const entries = [];
+  console.log = (value) => entries.push(String(value));
+  console.warn = (value) => entries.push(String(value));
+  console.error = (value) => entries.push(String(value));
+  return {
+    entries,
+    restore() {
+      console.log = original.log;
+      console.warn = original.warn;
+      console.error = original.error;
+    },
+  };
+}
+
+test('validates and normalizes a legitimate submission', () => {
+  const result = validateSubmission(validPayload({
+    enterprise: '  テスト株式会社  ',
+    email: ' visitor@example.net ',
+  }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.enterprise, 'テスト株式会社');
+  assert.equal(result.value.email, 'visitor@example.net');
+});
+
+test('rejects honeypot, fast submission, malformed fields and URL flooding', () => {
+  assert.equal(validateSubmission(validPayload({ website: 'filled' })).reason, 'honeypot_filled');
+  assert.equal(validateSubmission(validPayload({ formStartedAt: Date.now() - 100 })).reason, 'submission_too_fast');
+  assert.equal(validateSubmission(validPayload({ email: 'invalid' })).reason, 'field_validation_failed');
+  assert.equal(validateSubmission(validPayload({
+    inquiryDetails: 'https://a.test https://b.test https://c.test https://d.test https://e.test https://f.test',
+  })).reason, 'field_validation_failed');
+});
+
+test('serves public Turnstile configuration only to an allowed origin', async () => {
+  const env = validEnv();
+  const allowed = await handleRequest(new Request('https://contact.example/config', {
+    headers: { Origin: ORIGIN },
+  }), env);
+  assert.equal(allowed.status, 200);
+  assert.deepEqual(await allowed.json(), {
+    ok: true,
+    turnstileSiteKey: 'public-site-key',
+    turnstileAction: 'contact-submit',
+  });
+
+  const denied = await handleRequest(new Request('https://contact.example/config', {
+    headers: { Origin: 'https://attacker.example' },
+  }), env);
+  assert.equal(denied.status, 403);
+});
+
+test('rejects tokenless requests before rate limit or upstream processing', async () => {
+  const env = validEnv();
+  const audit = silenceAudit();
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error('fetch must not be called');
+  };
+  try {
+    const response = await handleRequest(submitRequest(validPayload({ turnstileToken: '' })), env);
+    assert.equal(response.status, 400);
+    assert.equal(fetchCalls, 0);
+    assert.equal(env.IP_RATE_LIMITER.calls.length, 0);
+    assert.equal(env.EMAIL_RATE_LIMITER.calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    audit.restore();
+  }
+});
+
+test('rejects a request when either layered rate limit is exceeded', async () => {
+  const env = validEnv({ IP_RATE_LIMITER: fakeLimiter(false) });
+  const audit = silenceAudit();
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error('fetch must not be called');
+  };
+  try {
+    const response = await handleRequest(submitRequest(validPayload()), env);
+    assert.equal(response.status, 429);
+    assert.equal(response.headers.get('Retry-After'), '60');
+    assert.equal(fetchCalls, 0);
+    assert.equal(env.IP_RATE_LIMITER.calls.length, 1);
+    assert.equal(env.EMAIL_RATE_LIMITER.calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    audit.restore();
+  }
+});
+
+test('rejects an invalid Turnstile result without contacting the receiver', async () => {
+  const env = validEnv();
+  const audit = silenceAudit();
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    return Response.json({ success: false, 'error-codes': ['invalid-input-response'] });
+  };
+  try {
+    const response = await handleRequest(submitRequest(validPayload()), env);
+    assert.equal(response.status, 400);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0], 'https://challenges.cloudflare.com/turnstile/v0/siteverify');
+    assert.equal(env.IP_RATE_LIMITER.calls.length, 1);
+    assert.equal(env.EMAIL_RATE_LIMITER.calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    audit.restore();
+  }
+});
+
+test('applies the reply-address limit only after Turnstile succeeds', async () => {
+  const env = validEnv({ EMAIL_RATE_LIMITER: fakeLimiter(false) });
+  const audit = silenceAudit();
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    return Response.json({
+      success: true,
+      hostname: 'www.abroad-o.com',
+      action: 'contact-submit',
+    });
+  };
+  try {
+    const response = await handleRequest(submitRequest(validPayload()), env);
+    assert.equal(response.status, 429);
+    assert.equal(calls.length, 1);
+    assert.equal(env.IP_RATE_LIMITER.calls.length, 1);
+    assert.equal(env.EMAIL_RATE_LIMITER.calls.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    audit.restore();
+  }
+});
+
+test('forwards a valid request with an HMAC signature and safe control flags', async () => {
+  const env = validEnv();
+  const audit = silenceAudit();
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url: String(url), options });
+    if (String(url).includes('/siteverify')) {
+      return Response.json({
+        success: true,
+        hostname: 'www.abroad-o.com',
+        action: 'contact-submit',
+      });
+    }
+    return Response.json({ ok: true });
+  };
+
+  try {
+    const response = await handleRequest(submitRequest(validPayload()), env);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, requestId: SUBMISSION_ID });
+    assert.equal(calls.length, 2);
+
+    const envelope = JSON.parse(calls[1].options.body);
+    const payload = JSON.parse(envelope.payload);
+    assert.equal(payload.requestId, SUBMISSION_ID);
+    assert.equal(payload.controls.notificationEnabled, true);
+    assert.equal(payload.controls.autoReplyEnabled, true);
+    assert.equal(
+      envelope.signature,
+      await keyedHash(env.UPSTREAM_SHARED_SECRET, envelope.payload),
+    );
+
+    const auditText = audit.entries.join('\n');
+    assert.equal(auditText.includes('visitor@example.net'), false);
+    assert.equal(auditText.includes('サービスについて相談'), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    audit.restore();
+  }
+});
+
+test('fails closed when required secrets or bindings are missing', async () => {
+  const env = validEnv({ TURNSTILE_SECRET_KEY: '' });
+  const audit = silenceAudit();
+  try {
+    const response = await handleRequest(submitRequest(validPayload()), env);
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), { ok: false, code: 'service_unavailable' });
+  } finally {
+    audit.restore();
+  }
+});

--- a/contact-worker/wrangler.jsonc
+++ b/contact-worker/wrangler.jsonc
@@ -1,0 +1,44 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "abroad-o-contact-form",
+  "main": "src/index.js",
+  "compatibility_date": "2026-08-03",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "vars": {
+    "ALLOWED_ORIGINS": "https://www.abroad-o.com,https://abroad-o.com",
+    "ALLOWED_HOSTNAMES": "www.abroad-o.com,abroad-o.com",
+    "UPSTREAM_ALLOWED_HOSTS": "script.google.com",
+    "TURNSTILE_ACTION": "contact-submit",
+    "NOTIFY_ENABLED": "true",
+    "AUTOREPLY_ENABLED": "true"
+  },
+  "ratelimits": [
+    {
+      "name": "IP_RATE_LIMITER",
+      "namespace_id": "27001",
+      "simple": {
+        "limit": 10,
+        "period": 60
+      }
+    },
+    {
+      "name": "EMAIL_RATE_LIMITER",
+      "namespace_id": "27002",
+      "simple": {
+        "limit": 3,
+        "period": 60
+      }
+    }
+  ],
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "head_sampling_rate": 1
+    },
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 0.05
+    }
+  }
+}

--- a/docs/contact-form-security.md
+++ b/docs/contact-form-security.md
@@ -1,0 +1,102 @@
+# 問い合わせフォーム bot対策・移行手順
+
+## 構成
+
+```text
+form.html
+  -> Cloudflare Turnstile widget
+  -> Cloudflare Worker /submit
+       1. Origin・サイズ・入力・honeypot・送信時間を検証
+       2. 送信元と宛先メールのHMAC値でレート制限
+       3. Turnstile Siteverifyでtoken・action・hostnameを検証
+       4. 検証済みデータへHMAC署名
+  -> Apps Script Web App
+       1. HMAC署名と受付ID重複を検証
+       2. Spreadsheetへ保存
+       3. 有効時のみ内部通知
+       4. 有効時のみ自動返信
+```
+
+公開HTMLへ置くのはWorkerのURLとTurnstileサイトキーだけです。Turnstileシークレット、受信WebアプリURL、共有鍵、通知先は公開しません。
+
+## 防御の考え方
+
+- TurnstileはWorkerからSiteverifyを呼び、`success`だけでなく`action`と`hostname`も確認する。
+- Turnstile tokenは5分・1回限りのため、エラー時はクライアントでwidgetをresetする。
+- IP制限は共有回線での誤検知を避けるため緩めの10件/分、同一返信先は3件/分とする。レート制限キーはHMAC化し、IP・メールアドレスを平文保存しない。
+- ランダム文字列らしさ、国外IP、フリーメールだけでは拒否しない。
+- ログには受付ID、結果、理由、短縮したHMAC値だけを記録し、氏名、メール、電話、本文を出さない。
+- WorkerとApps Scriptの両方で通知・自動返信を有効化しない限り、メールは送られない。通常の切替では両方を有効にし、新経路の開始時から自動返信を継続する。停止スイッチは異常時の緊急対応に限定する。
+- Apps Scriptは受付IDと内容指紋をSpreadsheetへ永続保存する。通知失敗時は状態を`待機`のまま残し、同じ受付ID・同じ内容の再送時だけ未完了処理を再開する。再開時にも現在のメール有効化設定を確認し、緊急停止中なら`待機`から`停止`へ変更して送信しない。異なる内容で同じ受付IDを使った要求は拒否する。
+
+## Cloudflare Workerの設定
+
+`contact-worker/` で作業する。
+
+```powershell
+npm install
+npm test
+npm run check
+```
+
+秘密値は`wrangler.jsonc`へ書かず、CloudflareのSecretとして登録する。
+
+```powershell
+npx wrangler secret put TURNSTILE_SECRET_KEY
+npx wrangler secret put RATE_LIMIT_HASH_KEY
+npx wrangler secret put UPSTREAM_URL
+npx wrangler secret put UPSTREAM_SHARED_SECRET
+```
+
+Turnstileサイトキーは公開値だが環境ごとのWorker変数`TURNSTILE_SITE_KEY`として設定する。`UPSTREAM_SHARED_SECRET`はApps Scriptの`CONTACT_SHARED_SECRET`と同じ十分に長いランダム値にする。値をコマンド履歴、Issue、ログへ貼り付けない。
+
+`abroad-o.com`のDNSゾーンをCloudflareで管理していないため、サイト全体のDNSへ影響を出さないよう、初回リリースは`https://abroad-o-contact-form.abroad-o.workers.dev`を使用する。将来Cloudflare側へDNSゾーンを追加する場合だけ、`https://contact.abroad-o.com`のCustom Domainへ切り替える。公開前に以下を確認する。
+
+- `/health` が200
+- 許可Originから`/config`が200、その他Originが403
+- tokenなし、無効token、異なるaction/hostnameが保存前に拒否される
+- 連投で429になる
+- Workerログに個人情報がない
+
+## Apps Scriptの設定
+
+`contact-worker/apps-script/`を専用のApps Scriptプロジェクトへ反映する。新しい台帳は既存の問い合わせ運用グループへ共有し、切替担当を含む必要な担当者が閲覧できることを先に確認する。内部通知先はScript Propertiesの`CONTACT_NOTIFY_EMAILS`へ設定し、実アドレスをソース、Issue、端末出力、ログへ置かない。本人限定Execution APIから`configureContactReceiver`を1回実行し、戻された共有鍵は画面やログへ出さずWorker Secretへ直接設定する。この初期化は通知先を上書きしない。`getContactConfigurationStatus`が成功し、保存先到達性、通知先件数、通知・自動返信ON、メール残量を返すことを公開条件とする。詳細は同フォルダのREADMEを参照する。
+
+本番切替前に、テスト用Spreadsheetと管理下のテスト用メールアドレスを使い、次の状態で自動返信まで確認する。
+
+```text
+CONTACT_NOTIFY_ENABLED=true
+CONTACT_AUTOREPLY_ENABLED=true
+```
+
+保存、内部通知、自動返信を一連で確認する。テストに実在する第三者のメールアドレスを使用しない。本番設定でも自動返信を有効にした状態で切り替える。
+
+## 旧Google Formsからの切替順序
+
+1. 旧Google Formに紐づく自動返信元、回答受付、トリガーを特定し、切替操作と確認方法を確定する。この段階では通常運用を停止しない。
+2. 新しい問い合わせ台帳を既存の問い合わせ運用グループへ共有し、必要な担当者の閲覧可否と旧回答データが保持されていることを確認する。
+3. テスト用Turnstile・Worker・Apps Script・Spreadsheet・管理下のテスト用メールアドレスで、保存・内部通知・自動返信と拒否系を確認する。
+4. Apps Script本番保存先とScript Propertiesの通知先を設定し、内部通知と自動返信を有効にする。Worker側も両方を有効にする。
+5. Workerを専用`workers.dev` URLで公開する。Cloudflare管理のDNSゾーンがある場合だけCustom Domainを割り当てる。公開フォームからはまだ参照しない。
+6. `form.html`をSakuraの既存手順でDryRun後に公開し、新経路へ切り替える。
+7. 公開ページから管理下のメールアドレスで1件だけ送信し、保存・内部通知・自動返信・ログを確認する。通常の受付フローが確認できるまで旧Google Formは停止しない。
+8. 通常フロー確認後、同じ切替作業内で旧Google Formの回答受付を停止し、既知の`formResponse`へ直接POSTしても保存・通知・自動返信されないことを確認する。
+9. 自動返信を継続したまま、受付数、拒否数、正規問い合わせ、バウンス、送信量を重点監視する。
+
+旧Google Formの停止前は、公開HTMLから送信先を除いても既知の`formResponse`へ直接POSTできるため、対策完了とはしない。
+
+本Issueは、旧Google Formの回答受付停止と旧自動返信経路の無効化を読み取り確認するまで完了扱いにしない。Worker・HTMLだけを公開して完了にしない。
+
+## ロールバック
+
+- 通常時は自動返信を継続する。明確な不正送信、バウンス急増、メール経路障害がある場合だけ、WorkerまたはApps Scriptの`AUTOREPLY_ENABLED`をfalseにして緊急停止する。
+- フォーム受付自体が不安定な場合は`NOTIFY_ENABLED`も停止し、画面上の代替メール・電話導線を利用する。
+- Sakura側HTMLはデプロイ前バックアップから復元できるが、旧Google Form直POST版は悪用経路を再開するため原則として復元しない。復旧までは代替連絡導線を使用する。
+- 新旧のSpreadsheet回答や受信メールは自動削除しない。旧Google Form停止後も過去データは保持し、参照可能な状態を維持する。
+
+## 監視
+
+- Workers Observabilityで`accepted`、`rejected`、`rate_limited`、`upstream_error`を集計する。
+- Google Workspace側で送信数、バウンス、迷惑メール報告、送信上限接近を確認する。
+- Spreadsheetの`内部通知状態`・`自動返信状態`に`待機`が残っていないか確認する。再送でも解消しない場合は行の内容を確認して手動対応する。
+- 拒否率が急増した場合は、自動返信だけを停止し、正規問い合わせの保存と内部確認を優先する。

--- a/form.html
+++ b/form.html
@@ -126,6 +126,13 @@
             width: 150px;
         }
 
+        .turnstile-container {
+            display: flex;
+            justify-content: center;
+            min-height: 70px;
+            margin: 1rem 0;
+        }
+
         /* 個人情報の取り扱いに関するテキストとチェックボックスを中央に配置 */
         .message-box {
             text-align: center;
@@ -337,9 +344,8 @@
             <div class="container">
                 <!-- フォームヘッダー -->
                 <h1 style="text-align: center;">お問い合わせ・お見積もりフォーム</h1>
-                <iframe id="form-submit-frame" name="form-submit-frame" title="お問い合わせフォーム送信用" style="display: none;" aria-hidden="true"></iframe>
                 <!-- フォーム全体 -->
-                <form action="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/formResponse" method="post" id="contactForm" target="form-submit-frame">
+                <form method="post" id="contactForm" data-contact-api="https://abroad-o-contact-form.abroad-o.workers.dev" novalidate>
                     <!-- フォームテーブル -->
                    <div id="form-tbl" class="form-group">
                         <table id="form" class="table" style="width: 100%;">
@@ -350,45 +356,45 @@
                             <!-- フォーム入力項目 -->
                             <div class="form-group">
                                 <label for="enterprise" class="must"><span class="badge badge-danger">必須</span> 企業名</label>
-                                <input type="text" id="enterprise" name="entry.2325062" class="form-control" required pattern=".*\S.*" placeholder="例：アブロードアウトソーシング株式会社">
+                                <input type="text" id="enterprise" name="enterprise" class="form-control" required maxlength="120" pattern=".*\S.*" placeholder="例：アブロードアウトソーシング株式会社">
                             </div>
 
                             <div class="form-group">
                                 <label for="department" class="nomust">部署・役職</label>
-                                <input type="text" id="department" name="entry.1000001" class="form-control" pattern=".*\S.*">
+                                <input type="text" id="department" name="department" class="form-control" maxlength="120">
                             </div>
 
                             <div class="form-group">
                                 <label for="name" class="must"><span class="badge badge-danger">必須</span> お名前</label>
-                                <input type="text" id="name" name="entry.1000002" class="form-control" required pattern=".*\S.*">
+                                <input type="text" id="name" name="name" class="form-control" required maxlength="80" pattern=".*\S.*">
                             </div>
 
                             <div class="form-group">
                                 <label for="email" class="must"><span class="badge badge-danger">必須</span> メールアドレス</label>
-                                <input type="email" id="email" name="entry.1000003" class="form-control" required pattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$" placeholder="例：info@abroad-o.com" title="正しいメールアドレスを入力してください。">
+                                <input type="email" id="email" name="email" class="form-control" required maxlength="254" placeholder="例：info@abroad-o.com" title="正しいメールアドレスを入力してください。">
                                 <span class="error-message">正しいメールアドレスを入力してください。</span>
                             </div>
 
                             <!-- ハニーポットフィールドの追加 -->
                             <div class="form-group honeypot" aria-hidden="true">
                                 <label for="honeypot_email" aria-hidden="true">メールアドレス（入力しないでください）</label>
-                                <input type="text" id="honeypot_email" name="entry.1234567890" class="form-control" tabindex="-1" autocomplete="off" aria-hidden="true">
+                                <input type="text" id="honeypot_email" name="website" class="form-control" tabindex="-1" autocomplete="off" aria-hidden="true">
                             </div>
 
                             <div class="form-group">
                                 <label for="phone" class="must"><span class="badge badge-danger">必須</span> 電話番号</label>
-                                <input type="tel" id="phone" name="entry.1000004" class="form-control" required pattern="^(?:\+81|0)\d{1,4}[- ]?\d{1,4}[- ]?\d{4}$" placeholder="例：03-5835-0250" title="電話番号の形式が正しくありません。例：03-5835-0250">
-                                <span class="error-message">電話番号の形式が正しくありません。例：03-5835-0250</span>
+                                <input type="tel" id="phone" name="phone" class="form-control" required maxlength="30" pattern="^[0-9+() -]{7,30}$" placeholder="例：03-5835-0250" title="電話番号の形式が正しくありません。例：03-5835-0250">
+                                <span class="error-message">電話番号の形式が正しくありません。</span>
                             </div>
 
                             <div class="form-group">
                                 <label for="address" class="nomust">住所</label>
-                                <textarea id="address" name="entry.1000749928" class="form-control" placeholder="例：東京都千代田区岩本町2-11-9 IT2ビル 8階"></textarea>
+                                <textarea id="address" name="address" class="form-control" maxlength="500" placeholder="例：東京都千代田区岩本町2-11-9 IT2ビル 8階"></textarea>
                             </div>
 
                             <div class="form-group">
                                  <label for="inquiry_details" class="must"><span class="badge badge-danger">必須</span> お問い合わせ内容</label>
-                                 <textarea id="inquiry_details" name="entry.1000005" class="form-control" required pattern=".*\S.*"></textarea>
+                                 <textarea id="inquiry_details" name="inquiryDetails" class="form-control" required maxlength="4000"></textarea>
                             </div>
                         </table>
                     </div>
@@ -480,19 +486,15 @@
                     <!-- 同意チェックボックス -->
                     <div class="form-group consent-container">
                         <label for="consent">
-                            <input type="checkbox" id="consent" name="entry.2027890221" required><span>個人情報の取扱について同意する。</span>
+                            <input type="checkbox" id="consent" name="consent" required><span>個人情報の取扱について同意する。</span>
                         </label>
                     </div>
+                    <div id="turnstile-container" class="turnstile-container" aria-label="bot対策の確認"></div>
+                    <noscript><p class="msg">送信にはJavaScriptが必要です。利用できない場合は、下記メールアドレスまたは電話番号からお問い合わせください。</p></noscript>
                     <!-- 送信ボタン -->
                     <div class="form-group mt-4 text-center">
-                        <input type="submit" value="送信する" class="btn btn-primary btn-submit">
+                        <input type="submit" value="送信する" class="btn btn-primary btn-submit" disabled>
                     </div>
-                    <!-- Google Formのhidden inputは送信に必要なので残す -->
-                    <input type="hidden" name="fvv" value="1">
-                    <input type="hidden" name="partialResponse" value="[null,null,"-1188643857103301952"]">
-                    <input type="hidden" name="pageHistory" value="0">
-                    <input type="hidden" name="fbzx" value="-1188643857103301952">
-
                 </form>
                 <!-- フォームフィードバックエリア -->
                 <div id="form-feedback" class="mt-3" aria-live="polite"></div>
@@ -512,126 +514,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-smooth-scroll/2.2.0/jquery.smoothscroll.min.js"></script> jQueryスムーズスクロールは後でプレーンJSに置き換え -->
 
-    <script>
-        const form = document.getElementById('contactForm');
-        const formFeedback = document.getElementById('form-feedback');
-        const honeypotField = document.getElementById('honeypot_email');
-        const emailField = document.getElementById('email');
-        const phoneField = document.getElementById('phone');
-        const inquiryDetailsField = document.getElementById('inquiry_details');
-        const emailError = emailField.nextElementSibling;
-        const phoneError = phoneField.nextElementSibling;
-        const submitButton = document.querySelector('.btn-submit');
-        const submitFrame = document.getElementById('form-submit-frame');
-        const emailPattern = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
-        const phonePattern = /^(?:\+81|0)\d{1,4}[- ]?\d{1,4}[- ]?\d{4}$/;
-        let submitted = false;
-
-        const params = new URLSearchParams(window.location.search);
-        if (params.get('service') === 'speed-ad' && inquiryDetailsField && inquiryDetailsField.value.trim() === '') {
-            inquiryDetailsField.value = 'SPEED ADについて相談したいです。';
-        }
-
-        function setFieldError(field, errorElement, hasError) {
-            field.classList.toggle('invalid', hasError);
-            errorElement.classList.toggle('error-visible', hasError);
-        }
-
-        [emailField, phoneField].forEach((field) => {
-            field.addEventListener('input', () => {
-                if (field === emailField) {
-                    setFieldError(emailField, emailError, !emailPattern.test(emailField.value.trim()));
-                } else {
-                    setFieldError(phoneField, phoneError, !phonePattern.test(phoneField.value.trim()));
-                }
-            });
-        });
-
-        // フォーム表示時刻を記録（ページロード時）
-        const formLoadTime = Date.now();
-        const MIN_SUBMISSION_TIME_MS = 3000; // 最低送信時間（ミリ秒、例: 3秒）
-
-        submitFrame.addEventListener('load', () => {
-            if (!submitted) {
-                return;
-            }
-
-            submitted = false;
-            window.location.href = 'thank.html';
-        });
-
-        form.addEventListener('submit', (event) => {
-            formFeedback.textContent = '';
-            formFeedback.style.color = '';
-            setFieldError(emailField, emailError, false);
-            setFieldError(phoneField, phoneError, false);
-
-            if (honeypotField.value !== '') {
-                console.warn('Bot detected via honeypot.');
-                event.preventDefault();
-                formFeedback.textContent = 'エラーが発生しました。再度お試しいただくか、別の方法でご連絡ください。';
-                formFeedback.style.color = 'red';
-                return;
-            }
-
-            const submissionTime = Date.now();
-            const elapsedTime = submissionTime - formLoadTime;
-
-            if (elapsedTime < MIN_SUBMISSION_TIME_MS) {
-                console.warn('Bot detected: Submission too fast.');
-                event.preventDefault();
-                formFeedback.textContent = 'エラーが発生しました。再度お試しいただくか、別の方法でご連絡ください。';
-                formFeedback.style.color = 'red';
-                return;
-            }
-
-            if (!emailPattern.test(emailField.value.trim())) {
-                event.preventDefault();
-                setFieldError(emailField, emailError, true);
-                emailField.focus();
-                return;
-            }
-
-            if (!phonePattern.test(phoneField.value.trim())) {
-                event.preventDefault();
-                setFieldError(phoneField, phoneError, true);
-                phoneField.focus();
-                return;
-            }
-
-            const consentCheckbox = document.getElementById('consent');
-            if (!consentCheckbox.checked) {
-                event.preventDefault();
-                alert('個人情報の取扱について同意をお願いします。');
-                return;
-            }
-
-            submitted = true;
-            submitButton.disabled = true;
-            formFeedback.textContent = '送信中です。';
-        });
-
-
-        // smoothScroll (jQuery 不要)
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            const targetSelector = anchor.getAttribute('href');
-            if (!targetSelector || targetSelector.length <= 1) {
-                return;
-            }
-
-            anchor.addEventListener('click', function (e) {
-                const target = document.querySelector(targetSelector);
-                if (!target) {
-                    return;
-                }
-
-                e.preventDefault();
-                target.scrollIntoView({
-                    behavior: 'smooth'
-                });
-            });
-        });
-
-    </script>
+    <script src="js/contact-form.js?v=20260803-security"></script>
 </body>
 </html>

--- a/js/contact-form.js
+++ b/js/contact-form.js
@@ -1,0 +1,226 @@
+(function () {
+    'use strict';
+
+    const form = document.getElementById('contactForm');
+    if (!form) {
+        return;
+    }
+
+    const apiBaseUrl = String(form.dataset.contactApi || '').replace(/\/$/, '');
+    const formFeedback = document.getElementById('form-feedback');
+    const emailField = document.getElementById('email');
+    const phoneField = document.getElementById('phone');
+    const inquiryDetailsField = document.getElementById('inquiry_details');
+    const emailError = emailField.nextElementSibling;
+    const phoneError = phoneField.nextElementSibling;
+    const submitButton = form.querySelector('.btn-submit');
+    const consentCheckbox = document.getElementById('consent');
+    const formLoadTime = Date.now();
+    const submissionId = typeof window.crypto.randomUUID === 'function'
+        ? window.crypto.randomUUID()
+        : createUuid(window.crypto);
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+    const phonePattern = /^[0-9+() -]{7,30}$/;
+    let turnstileToken = '';
+    let turnstileWidgetId = null;
+    let submitting = false;
+
+    function createUuid(cryptoApi) {
+        const bytes = new Uint8Array(16);
+        cryptoApi.getRandomValues(bytes);
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+        return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('service') === 'speed-ad' && inquiryDetailsField.value.trim() === '') {
+        inquiryDetailsField.value = 'SPEED ADについて相談したいです。';
+    }
+
+    function setFeedback(message, isError) {
+        formFeedback.textContent = message;
+        formFeedback.style.color = isError ? 'red' : '';
+    }
+
+    function setFieldError(field, errorElement, hasError) {
+        field.classList.toggle('invalid', hasError);
+        field.setAttribute('aria-invalid', String(hasError));
+        errorElement.classList.toggle('error-visible', hasError);
+    }
+
+    function resetTurnstile() {
+        turnstileToken = '';
+        if (window.turnstile && turnstileWidgetId !== null) {
+            window.turnstile.reset(turnstileWidgetId);
+        }
+    }
+
+    function loadTurnstileScript() {
+        return new Promise((resolve, reject) => {
+            if (window.turnstile) {
+                resolve();
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+            script.async = true;
+            script.defer = true;
+            script.onload = resolve;
+            script.onerror = () => reject(new Error('turnstile_script_failed'));
+            document.head.appendChild(script);
+        });
+    }
+
+    async function initializeTurnstile() {
+        if (!apiBaseUrl) {
+            throw new Error('contact_api_not_configured');
+        }
+
+        const [configResponse] = await Promise.all([
+            fetch(`${apiBaseUrl}/config`, {
+                method: 'GET',
+                mode: 'cors',
+                cache: 'no-store',
+                credentials: 'omit'
+            }),
+            loadTurnstileScript()
+        ]);
+
+        if (!configResponse.ok) {
+            throw new Error('contact_config_unavailable');
+        }
+
+        const config = await configResponse.json();
+        if (!config.turnstileSiteKey) {
+            throw new Error('turnstile_site_key_missing');
+        }
+
+        turnstileWidgetId = window.turnstile.render('#turnstile-container', {
+            sitekey: config.turnstileSiteKey,
+            action: config.turnstileAction || 'contact-submit',
+            callback: (token) => {
+                turnstileToken = token;
+                submitButton.disabled = false;
+                setFeedback('', false);
+            },
+            'expired-callback': () => {
+                turnstileToken = '';
+                submitButton.disabled = true;
+                setFeedback('確認の有効期限が切れました。もう一度確認してください。', true);
+            },
+            'error-callback': () => {
+                turnstileToken = '';
+                submitButton.disabled = true;
+                setFeedback('bot対策の確認を読み込めませんでした。時間をおいて再度お試しいただくか、別の方法でご連絡ください。', true);
+            }
+        });
+    }
+
+    [emailField, phoneField].forEach((field) => {
+        field.addEventListener('input', () => {
+            if (field === emailField) {
+                setFieldError(emailField, emailError, !emailPattern.test(emailField.value.trim()));
+            } else {
+                setFieldError(phoneField, phoneError, !phonePattern.test(phoneField.value.trim()));
+            }
+        });
+    });
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (submitting) {
+            return;
+        }
+
+        setFeedback('', false);
+        setFieldError(emailField, emailError, false);
+        setFieldError(phoneField, phoneError, false);
+
+        if (!form.reportValidity()) {
+            return;
+        }
+        if (!emailPattern.test(emailField.value.trim())) {
+            setFieldError(emailField, emailError, true);
+            emailField.focus();
+            return;
+        }
+        if (!phonePattern.test(phoneField.value.trim())) {
+            setFieldError(phoneField, phoneError, true);
+            phoneField.focus();
+            return;
+        }
+        if (!consentCheckbox.checked) {
+            setFeedback('個人情報の取扱について同意をお願いします。', true);
+            consentCheckbox.focus();
+            return;
+        }
+        if (!turnstileToken) {
+            setFeedback('bot対策の確認を完了してください。', true);
+            return;
+        }
+
+        submitting = true;
+        submitButton.disabled = true;
+        setFeedback('送信中です。', false);
+
+        const payload = {
+            submissionId,
+            enterprise: document.getElementById('enterprise').value,
+            department: document.getElementById('department').value,
+            name: document.getElementById('name').value,
+            email: emailField.value,
+            phone: phoneField.value,
+            address: document.getElementById('address').value,
+            inquiryDetails: inquiryDetailsField.value,
+            consent: consentCheckbox.checked,
+            website: document.getElementById('honeypot_email').value,
+            formStartedAt: formLoadTime,
+            turnstileToken
+        };
+
+        try {
+            const response = await fetch(`${apiBaseUrl}/submit`, {
+                method: 'POST',
+                mode: 'cors',
+                cache: 'no-store',
+                credentials: 'omit',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            const result = await response.json().catch(() => ({}));
+            if (!response.ok || !result.ok) {
+                throw new Error(result.code || 'contact_submit_failed');
+            }
+
+            window.location.href = 'thank.html';
+        } catch (error) {
+            submitting = false;
+            submitButton.disabled = true;
+            resetTurnstile();
+            setFeedback('送信できませんでした。時間をおいて再度お試しいただくか、別の方法でご連絡ください。', true);
+        }
+    });
+
+    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+        const targetSelector = anchor.getAttribute('href');
+        if (!targetSelector || targetSelector.length <= 1) {
+            return;
+        }
+        anchor.addEventListener('click', (event) => {
+            const target = document.querySelector(targetSelector);
+            if (!target) {
+                return;
+            }
+            event.preventDefault();
+            target.scrollIntoView({ behavior: 'smooth' });
+        });
+    });
+
+    initializeTurnstile().catch(() => {
+        submitButton.disabled = true;
+        setFeedback('現在フォームを利用できません。時間をおいて再度お試しいただくか、下記メールアドレスまたは電話番号からご連絡ください。', true);
+    });
+}());


### PR DESCRIPTION
## 概要

Closes #27

- 公開フォームをTurnstile + Cloudflare Worker + HMAC署名済みApps Script受信経路へ変更
- サーバー側でOrigin、入力、honeypot、送信時間、レート制限、Turnstileを検証
- 受付台帳への保存、内部通知、自動返信の制御と重複受付防止を追加
- 新台帳の既存問い合わせ運用グループ共有、Script Propertiesによる通知先設定、正常フロー確認後の旧フォーム停止・旧データ保持を運用手順へ明記

## 検証

- `npm test`（17件成功）
- `npm audit --omit=dev`（脆弱性なし）
- `npm run check`（構文確認・Wrangler dry-run成功）
- `git diff --check`
- ステージ済み変更の秘密情報・想定外メールアドレススキャン

## 影響

本PRは実装と手順のみで、本番デプロイ、Apps Script設定変更、旧フォーム停止、外部送信は含みません。切替時は文書化した通常フロー確認後に旧経路を停止します。