### PR TITLE
fix: 公開フォームの本番差分を同期

### DIFF
--- a/form.html
+++ b/form.html
@@ -514,6 +514,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-smooth-scroll/2.2.0/jquery.smoothscroll.min.js"></script> jQueryスムーズスクロールは後でプレーンJSに置き換え -->
 
-    <script src="js/contact-form.js?v=20260803-security"></script>
+    <script src="js/contact-form.js?v=20260808-turnstile-light"></script>
 </body>
 </html>

--- a/js/contact-form.js
+++ b/js/contact-form.js
@@ -101,6 +101,7 @@
         turnstileWidgetId = window.turnstile.render('#turnstile-container', {
             sitekey: config.turnstileSiteKey,
             action: config.turnstileAction || 'contact-submit',
+            theme: 'light',
             callback: (token) => {
                 turnstileToken = token;
                 submitButton.disabled = false;

--- a/scripts/deploy-sakura.ps1
+++ b/scripts/deploy-sakura.ps1
@@ -311,15 +311,28 @@ function Invoke-ContentAudit {
 set -eu
 REMOTE_DIR='$RemoteDirectory'
 cd "`$REMOTE_DIR"
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_COMMAND='sha256sum'
+elif command -v shasum >/dev/null 2>&1; then
+  HASH_COMMAND='shasum -a 256'
+else
+  echo 'Neither sha256sum nor shasum is available on the remote host.' >&2
+  exit 1
+fi
+HASH_LIST=`$(mktemp)
+trap 'rm -f "`$HASH_LIST"' EXIT
 while IFS= read -r path; do
   if [ -f "`$path" ]; then
-    sha256sum "`$path"
+    printf '%s\n' "`$path" >> "`$HASH_LIST"
   else
     printf 'MISSING  %s\n' "`$path"
   fi
 done <<'CODEX_MANIFEST'
 $manifestBody
 CODEX_MANIFEST
+if [ -s "`$HASH_LIST" ]; then
+  xargs `$HASH_COMMAND < "`$HASH_LIST"
+fi
 "@
 
     $remoteOutput = Invoke-RemoteScriptOutput -Script $auditScript

--- a/scripts/deploy-sakura.ps1
+++ b/scripts/deploy-sakura.ps1
@@ -1,5 +1,5 @@
 param(
-    [ValidateSet("Package", "DryRun", "Deploy", "Verify", "Restore")]
+    [ValidateSet("Package", "DryRun", "Audit", "Deploy", "Verify", "Restore")]
     [string]$Mode = "DryRun",
 
     [string]$ConfigPath = "deploy/sakura-public-files.json",
@@ -245,7 +245,7 @@ function Get-RemoteDir {
 }
 
 function Get-SshArgs {
-    $args = @("-p", "$Port", "-o", "IdentitiesOnly=yes", "-o", "StrictHostKeyChecking=accept-new")
+    $args = @("-p", "$Port", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15", "-o", "IdentitiesOnly=yes", "-o", "StrictHostKeyChecking=accept-new")
     if ($SshKeyPath) {
         $args += @("-i", $SshKeyPath)
     }
@@ -253,7 +253,7 @@ function Get-SshArgs {
 }
 
 function Get-ScpArgs {
-    $args = @("-P", "$Port", "-o", "IdentitiesOnly=yes", "-o", "StrictHostKeyChecking=accept-new")
+    $args = @("-P", "$Port", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15", "-o", "IdentitiesOnly=yes", "-o", "StrictHostKeyChecking=accept-new")
     if ($SshKeyPath) {
         $args += @("-i", $SshKeyPath)
     }
@@ -271,6 +271,93 @@ function Invoke-RemoteScript {
     if ($LASTEXITCODE -ne 0) {
         throw "Remote command failed."
     }
+}
+
+function Invoke-RemoteScriptOutput {
+    param([string]$Script)
+    $target = Get-SshTarget
+    $sshArgs = Get-SshArgs
+    $scriptPath = Join-Path $workDirFullPath "remote-audit.sh"
+    $normalizedScript = ($Script -replace "`r`n", "`n") -replace "`r", "`n"
+    [System.IO.File]::WriteAllText($scriptPath, $normalizedScript, [System.Text.UTF8Encoding]::new($false))
+    $output = & cmd.exe /c "type `"$scriptPath`" | ssh $($sshArgs -join ' ') $target `"sh -s`""
+    if ($LASTEXITCODE -ne 0) {
+        throw "Remote command failed."
+    }
+    return @($output)
+}
+
+function Invoke-ContentAudit {
+    param(
+        [object]$Package,
+        [string]$RemoteDirectory
+    )
+
+    $manifest = @(Get-Content -LiteralPath $Package.ManifestPath)
+    foreach ($path in $manifest) {
+        if ($path -notmatch '^[A-Za-z0-9._/@+-]+$') {
+            throw "Audit does not support this public path: $path"
+        }
+    }
+
+    $localHashes = @{}
+    foreach ($path in $manifest) {
+        $localPath = Join-Path $Package.StagingDir $path
+        $localHashes[$path] = (Get-FileHash -LiteralPath $localPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+
+    $manifestBody = $manifest -join "`n"
+    $auditScript = @"
+set -eu
+REMOTE_DIR='$RemoteDirectory'
+cd "`$REMOTE_DIR"
+while IFS= read -r path; do
+  if [ -f "`$path" ]; then
+    sha256sum "`$path"
+  else
+    printf 'MISSING  %s\n' "`$path"
+  fi
+done <<'CODEX_MANIFEST'
+$manifestBody
+CODEX_MANIFEST
+"@
+
+    $remoteOutput = Invoke-RemoteScriptOutput -Script $auditScript
+    $remoteHashes = @{}
+    $missing = @()
+    foreach ($line in $remoteOutput) {
+        if ($line -match '^MISSING\s{2}(.+)$') {
+            $missing += $Matches[1]
+            continue
+        }
+        if ($line -match '^([0-9a-fA-F]{64})\s+\*?(.+)$') {
+            $remoteHashes[$Matches[2]] = $Matches[1].ToLowerInvariant()
+        }
+    }
+
+    $different = @()
+    foreach ($path in $manifest) {
+        if ($remoteHashes.ContainsKey($path) -and $remoteHashes[$path] -ne $localHashes[$path]) {
+            $different += $path
+        }
+    }
+
+    foreach ($path in $missing) {
+        Write-Host "MISSING $path"
+    }
+    foreach ($path in $different) {
+        Write-Host "DIFFERENT $path"
+    }
+
+    Write-Host "Audit files: $($manifest.Count)"
+    Write-Host "Audit missing: $($missing.Count)"
+    Write-Host "Audit different: $($different.Count)"
+
+    if ($missing.Count -gt 0 -or $different.Count -gt 0) {
+        throw "Public content audit found drift."
+    }
+
+    Write-Host "Public content audit passed."
 }
 
 function Invoke-Verification {
@@ -372,6 +459,11 @@ foreach ($path in $excludedChecks) {
         throw "Excluded path was included in package: $path"
     }
     Write-Host "Excluded check passed: $path"
+}
+
+if ($Mode -eq "Audit") {
+    Invoke-ContentAudit -Package $package -RemoteDirectory (Get-RemoteDir)
+    exit 0
 }
 
 if ($Mode -eq "Package" -or $Mode -eq "DryRun") {


### PR DESCRIPTION
## 変更内容
- 公開中フォームに合わせてTurnstileのlightテーマとキャッシュキーを同期
- Sakura上の管理対象ファイルをパスとSHA-256で比較する読み取り専用Auditモードを追加
- SSH接続を非対話化し、Sakura環境のshasumにも対応

## 動作確認
- 問い合わせWorkerテスト 27件合格
- PowerShell構文検査合格
- DryRunで635ファイルを梱包し、アップロードなし
- Auditで635ファイルを比較可能

## 影響範囲
- form.html、js/contact-form.js、Sakura公開スクリプト
- 本PRでは本番公開を実施しない