### PR TITLE
refactor: 旧問い合わせフォームを完全撤去

### DIFF
--- a/about.html
+++ b/about.html
@@ -99,7 +99,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -291,37 +291,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <!-- Modal -->
-  <div class="modal fade" id="myModal2" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScbeS-kxx7YT_ONfPENKkqfBis4d_Rd2O3pri_WRoAO0xGMDg/viewform?embedded=true" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/aggregate.html
+++ b/aggregate.html
@@ -113,7 +113,7 @@
               </ul>
             </li>
         <!-- CONTACT -->
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -254,21 +254,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-    <!-- モーダルウィンドウ -->
-    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/edit.html
+++ b/edit.html
@@ -103,7 +103,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div>
@@ -390,21 +390,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/film.html
+++ b/film.html
@@ -99,7 +99,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div>
@@ -395,21 +395,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/form.html
+++ b/form.html
@@ -331,7 +331,7 @@
                                         <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
                                     </ul>
                                 </li>
-                                <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+                                <li><a class="page-scroll" href="form.html">CONTACT</a></li>
                             </ul>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
                     </li>
                     <!-- CONTACT -->
                     <li class="nav-item">
-                        <a class="nav-link page-scroll" href="about.html#contact_up">CONTACT</a>
+                        <a class="nav-link page-scroll" href="form.html">CONTACT</a>
                     </li>
                 </ul>
             </div>

--- a/input.html
+++ b/input.html
@@ -112,7 +112,7 @@
               </ul>
             </li>
         <!-- CONTACT -->
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -663,23 +663,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-    <!-- モーダルウィンドウ -->
-    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
-    <!-- 各種JavaScriptファイルの読み込み -->
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <!-- Bootstrap JS -->

--- a/largeformat.html
+++ b/largeformat.html
@@ -102,7 +102,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -412,37 +412,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <!-- Modal -->
-  <div class="modal fade" id="myModal2" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScbeS-kxx7YT_ONfPENKkqfBis4d_Rd2O3pri_WRoAO0xGMDg/viewform?embedded=true" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/microfilm.html
+++ b/microfilm.html
@@ -97,7 +97,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -400,21 +400,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/news.html
+++ b/news.html
@@ -173,7 +173,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_171023.html
+++ b/news/news_171023.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_17110101.html
+++ b/news/news_17110101.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_17110102.html
+++ b/news/news_17110102.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_17110103.html
+++ b/news/news_17110103.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_171211.html
+++ b/news/news_171211.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_18083101.html
+++ b/news/news_18083101.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_18083102.html
+++ b/news/news_18083102.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_181220.html
+++ b/news/news_181220.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_190327.html
+++ b/news/news_190327.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_191227.html
+++ b/news/news_191227.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_200106.html
+++ b/news/news_200106.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_200327.html
+++ b/news/news_200327.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_200508.html
+++ b/news/news_200508.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_200526.html
+++ b/news/news_200526.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_200721.html
+++ b/news/news_200721.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_201106.html
+++ b/news/news_201106.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_210329.html
+++ b/news/news_210329.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_220807.html
+++ b/news/news_220807.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_221212.html
+++ b/news/news_221212.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_231226.html
+++ b/news/news_231226.html
@@ -65,7 +65,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_241218.html
+++ b/news/news_241218.html
@@ -71,7 +71,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_250827.html
+++ b/news/news_250827.html
@@ -159,7 +159,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_250908.html
+++ b/news/news_250908.html
@@ -159,7 +159,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_251212.html
+++ b/news/news_251212.html
@@ -130,7 +130,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_260526.html
+++ b/news/news_260526.html
@@ -148,7 +148,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_260615.html
+++ b/news/news_260615.html
@@ -148,7 +148,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/news/news_260616.html
+++ b/news/news_260616.html
@@ -149,7 +149,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->

--- a/recruit.html
+++ b/recruit.html
@@ -99,7 +99,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -129,21 +129,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/rule.html
+++ b/rule.html
@@ -98,7 +98,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -264,21 +264,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/sample.html
+++ b/sample.html
@@ -98,7 +98,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -221,21 +221,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/sample2.html
+++ b/sample2.html
@@ -98,7 +98,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div><!--nav-->
@@ -151,21 +151,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/scan.html
+++ b/scan.html
@@ -93,7 +93,7 @@
                     </li>
                     <!-- CONTACT -->
                     <li class="nav-item">
-                        <a class="nav-link page-scroll" href="about.html#contact_up">CONTACT</a>
+                        <a class="nav-link page-scroll" href="form.html">CONTACT</a>
                     </li>
                 </ul>
             </div>

--- a/service-pack.html
+++ b/service-pack.html
@@ -98,7 +98,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div>
@@ -324,9 +324,9 @@
             </ul>
         </div>
         <div class="btn_center">
-          <button type="button" class="btn btn-danger btn-lg" data-toggle="modal" data-target="#myModal2">
+          <a class="btn btn-danger btn-lg" href="form.html">
             <p><strong>≪　らくらくスキャンパックのお問合わせはこちら　≫</strong></p>
-          </button>
+          </a>
         </div>
       </div><!--container-->
     </section>
@@ -475,37 +475,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <!-- Modal -->
-  <div class="modal fade" id="myModal2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScbeS-kxx7YT_ONfPENKkqfBis4d_Rd2O3pri_WRoAO0xGMDg/viewform?embedded=true" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/service.html
+++ b/service.html
@@ -181,7 +181,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div>
@@ -289,21 +289,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/slick/largeformat.html
+++ b/slick/largeformat.html
@@ -92,7 +92,7 @@
                 <li class="not_top not_border"><a href="../recruit.html">リクルート</a></li>                  
               </ul>  
             </li>                 
-            <li><a class="page-scroll" href="../about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="../form.html">CONTACT</a></li>
           </ul>
           </div>
         </div> 
@@ -399,37 +399,7 @@
       <!---スクロールボタン-->  
       <p id="page-top"><a href="#header_top"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a></p>  
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" tabindex="1" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
-  
-  <!-- Modal -->
-  <div class="modal fade" id="myModal2" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" tabindex="1" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScbeS-kxx7YT_ONfPENKkqfBis4d_Rd2O3pri_WRoAO0xGMDg/viewform?embedded=true" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- FontAwesome CDN -->
     <script src="https://use.fontawesome.com/297671da61.js"></script>

--- a/speed-ad.html
+++ b/speed-ad.html
@@ -1346,7 +1346,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div>

--- a/telework.html
+++ b/telework.html
@@ -98,7 +98,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>
               </ul>
             </li>
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div>
@@ -314,21 +314,7 @@
       <!---スクロールボタン-->
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close" accesskey="U"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" title="お問合わせフォーム">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/thank.html
+++ b/thank.html
@@ -84,7 +84,7 @@
                 <li class="not_top not_border"><a href="recruit.html">リクルート</a></li>                  
               </ul>  
             </li>                 
-            <li><a class="page-scroll" href="about.html#contact_up">CONTACT</a></li>
+            <li><a class="page-scroll" href="form.html">CONTACT</a></li>
           </ul>
           </div>
         </div> 
@@ -125,21 +125,7 @@
       <!---スクロールボタン-->  
       <a href="#" id="page-top" aria-label="ページトップへ戻る"><i class="fa fa-arrow-circle-up fa-3x" aria-hidden="true"></i></a>  
     </footer>
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSducG_PN_pRRvNlEyEjI8RRUJbhFLKXPr--iopScCsDZhkZ9A/viewform?embedded=true#start=embed" width="580" height="1180" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます...</iframe>
-        </div>
-        <div class="modal-footer">
-        </div>
-      </div>
-    </div>
-  </div>
+
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>


### PR DESCRIPTION
## 変更内容
- 16ページからGoogle Forms iframe、旧モーダル、関連トリガーを撤去
- 全問い合わせCTAを現行のform.htmlへ統一
- 現行フォームとCloudflare Workerの受付フローは維持

## 動作確認
- 旧Google Forms参照、旧フォームID、旧モーダル参照が0件
- 内部リンク検査合格
- 問い合わせWorkerテスト 27件合格
- DryRunで635ファイルを梱包し、アップロードなし

## 影響範囲
- 企業サイトとNEWSの問い合わせ導線
- 旧Google Form本体、過去回答、台帳は変更・削除しない
- Google Formの受付停止と通知トリガー無効化は本番反映確認後に別途実施