### PR TITLE
fix: フォームページの見出し文言を維持

### DIFF
--- a/site/_includes/partials/header-legacy.njk
+++ b/site/_includes/partials/header-legacy.njk
@@ -8,7 +8,7 @@
           <div class="col-sm-8 col-md-6 right">
             <ul>
               <li><i class="fa fa-phone-square" aria-hidden="true"></i>　03-5835-0250（平日10時~19時）</li>
-              <li><i class="fa fa-wpforms" aria-hidden="true"></i>　<a href="/form.html" class="no-link-style">フォームでのお問合わせ</a></li>
+              <li><i class="fa fa-wpforms" aria-hidden="true"></i>　<a href="/form.html" class="no-link-style">{{ headerContactLabel or "フォームでのお問合わせ" }}</a></li>
             </ul>
           </div>
         </div>

--- a/site/pages/form.html.njk
+++ b/site/pages/form.html.njk
@@ -5,6 +5,7 @@ description: "アブロードアウトソーシング株式会社へのお問い
 canonicalUrl: "https://www.abroad-o.com/form.html"
 layoutVariant: "legacy"
 activeNav: "contact"
+headerContactLabel: "お問い合わせフォーム"
 ---
 {% extends "layouts/site.njk" %}
 

--- a/site/pages/thank.html.njk
+++ b/site/pages/thank.html.njk
@@ -5,6 +5,7 @@ description: "お問い合わせ・お見積もりのご依頼を受け付けま
 canonicalUrl: "https://www.abroad-o.com/thank.html"
 layoutVariant: "legacy"
 activeNav: "contact"
+headerContactLabel: "フォームでのお問い合わせ"
 ---
 {% extends "layouts/site.njk" %}
 


### PR DESCRIPTION
## 変更内容
- 共通ヘッダーの問い合わせラベルをページ変数で上書き可能に変更
- `form.html`を「お問い合わせフォーム」へ復元
- `thank.html`を「フォームでのお問い合わせ」へ復元

## 動作確認
- Node.js 22で`npm run check:site`成功
- 47生成ページ、全53 HTMLの検査成功
- 第2段階公開物との表示本文比較: 47/47一致
- 旧Google Form禁止参照: 0件
- 決定的マニフェストSHA-256一致

## 影響範囲
- `form.html`と`thank.html`のヘッダー表示文言のみ
- 公開URL、本文、フォーム項目、Worker APIは変更しない